### PR TITLE
replace mp3 with ogg and proper filetype recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# this fork
+- i replaced the usage of mp3s with oggs for better quality and timing
+- i made it properly read the filetype instead of using the file extension as the filetype
+
 # osu-trainer
 A program that allows you to modify the difficulty of a beatmap **very quickly and easily**.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-# this fork
-- i replaced the usage of mp3s with oggs for better quality and timing
-- i made it properly read the filetype instead of using the file extension as the filetype
-
 # osu-trainer
 A program that allows you to modify the difficulty of a beatmap **very quickly and easily**.
 

--- a/osu-trainer/App.config
+++ b/osu-trainer/App.config
@@ -1,26 +1,38 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
         <sectionGroup name="userSettings" type="System.Configuration.UserSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <section name="osu_trainer.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false"/>
+            <section name="osu_trainer.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" allowExeDefinition="MachineToLocalUser" requirePermission="false" />
         </sectionGroup>
     </configSections>
     <startup> 
         
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" /></startup>
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-            <probing privatePath="lib"/>
+            <probing privatePath="lib" />
             <dependentAssembly>
-                <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-                <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
+                <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-7.0.0.2" newVersion="7.0.0.2" />
             </dependentAssembly>
         </assemblyBinding>
     </runtime>
     <userSettings>
         <osu_trainer.Properties.Settings>
             <setting name="SongsFolder" serializeAs="String">
-                <value/>
+                <value />
             </setting>
             <setting name="NoSpinners" serializeAs="String">
                 <value>False</value>

--- a/osu-trainer/BeatmapEditor.cs
+++ b/osu-trainer/BeatmapEditor.cs
@@ -829,7 +829,7 @@ namespace osu_trainer
                 map.AudioFilename = $"{Path.GetFileNameWithoutExtension(map.AudioFilename)} {multiplier:0.000}x withDT";
                 if (changePitch && Math.Abs(multiplier - 1M) > 0.001M)
                     map.AudioFilename += $" (pitch {(multiplier < 1 ? "lowered" : "raised")})";
-                map.AudioFilename += ".mp3";
+                map.AudioFilename += ".ogg";
             }
             else if (Math.Abs(multiplier - 1M) > 0.001M)
             {
@@ -838,7 +838,7 @@ namespace osu_trainer
                 map.AudioFilename = $"{Path.GetFileNameWithoutExtension(map.AudioFilename)} {multiplier:0.000}x";
                 if (changePitch)
                     map.AudioFilename += $" (pitch {(multiplier < 1 ? "lowered" : "raised")})";
-                map.AudioFilename += ".mp3";
+                map.AudioFilename += ".ogg";
             }
 
             // Difficulty Name - Difficulty Settings

--- a/osu-trainer/osu-trainer.csproj
+++ b/osu-trainer/osu-trainer.csproj
@@ -80,8 +80,17 @@
     <SignManifests>false</SignManifests>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FSharp.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FSharp.Core.8.0.100\lib\netstandard2.0\FSharp.Core.dll</HintPath>
+    <Reference Include="FFMpegCore, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\FFMpegCore.5.1.0\lib\netstandard2.0\FFMpegCore.dll</HintPath>
+    </Reference>
+    <Reference Include="FSharp.Core, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FSharp.Core.9.0.100\lib\netstandard2.0\FSharp.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Instances, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Instances.3.0.0\lib\netstandard2.0\Instances.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.7.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Win32.Registry, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Win32.Registry.4.7.0\lib\net461\Microsoft.Win32.Registry.dll</HintPath>
@@ -135,8 +144,8 @@
       <HintPath>..\packages\ProcessMemoryDataFinder.0.8.5\lib\net472\ProcessMemoryDataFinder.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -145,17 +154,17 @@
     </Reference>
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
-    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
     <Reference Include="System.Resources.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
@@ -167,6 +176,15 @@
     </Reference>
     <Reference Include="System.Security.Principal.Windows, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Security.Principal.Windows.4.7.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.7.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=7.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.7.0.2\lib\net462\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>

--- a/osu-trainer/packages.config
+++ b/osu-trainer/packages.config
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSharp.Core" version="8.0.100" targetFramework="net48" />
+  <package id="FFMpegCore" version="5.1.0" targetFramework="net48" />
+  <package id="FSharp.Core" version="9.0.100" targetFramework="net48" />
+  <package id="Instances" version="3.0.0" targetFramework="net48" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.Win32.Registry" version="4.7.0" targetFramework="net472" />
   <package id="Microsoft.WindowsAPICodePack-Core" version="1.1.0.2" targetFramework="net471" />
@@ -18,14 +21,17 @@
   <package id="NVorbis" version="0.10.4" targetFramework="net472" />
   <package id="OsuMemoryDataProvider" version="0.10.3" targetFramework="net48" />
   <package id="ProcessMemoryDataFinder" version="0.8.5" targetFramework="net472" />
-  <package id="System.Buffers" version="4.4.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Data.DataSetExtensions" version="4.5.0" targetFramework="net472" />
   <package id="System.Drawing.Common" version="6.0.0" targetFramework="net471" />
-  <package id="System.Memory" version="4.5.3" targetFramework="net472" />
-  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net471" />
   <package id="System.Security.AccessControl" version="4.7.0" targetFramework="net472" />
   <package id="System.Security.Principal.Windows" version="4.7.0" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="7.0.0" targetFramework="net48" />
+  <package id="System.Text.Json" version="7.0.2" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net471" />
 </packages>


### PR DESCRIPTION
Replaced the sped up audio filetype with ogg using an ffmpeg wrapper since its better in quality with lower filesize and also has consistent offset unlike mp3 making timing way more accurate (low quality will now be 128bkps and high quality 192kbps)

I also fixed the filetype recognition to actually read the filetype rather than assuming the extension is accurate. (It's a bit janky with little and big endian but it works). Example map for when this would cause issues: https://osu.ppy.sh/beatmapsets/1347975


i had to update to fsharp 9 from 8 for it to work.
vs added some system references by itself, idk why
